### PR TITLE
Push: Fix HTTP/2 always sending to the first endpoint

### DIFF
--- a/ApnsPHP/Message.php
+++ b/ApnsPHP/Message.php
@@ -107,6 +107,28 @@ class ApnsPHP_Message
 	}
 
 	/**
+	 * Get a recipient.
+	 *
+	 * @param  $nRecipient @type integer @optional Recipient number to return.
+	 * @throws ApnsPHP_Message_Exception if no recipient number
+	 *         exists.
+	 * @return @type string The recipient token at index $nRecipient.
+	 */
+	public function selfForRecipient($nRecipient = 0)
+	{
+		if (!isset($this->_aDeviceTokens[$nRecipient])) {
+			throw new ApnsPHP_Message_Exception(
+				"No recipient at index '{$nRecipient}'"
+			);
+		}
+
+		$copy = clone $this;
+		$copy->_aDeviceTokens = [$this->_aDeviceTokens[$nRecipient]];
+
+		return $copy;
+	}
+
+	/**
 	 * Get the number of recipients.
 	 *
 	 * @return @type integer Recipient's number.

--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -117,7 +117,7 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 		for ($i = 0; $i < $nRecipients; $i++) {
 			$nMessageID = $nMessageQueueLen + $i + 1;
 			$aMessage = array(
-				'MESSAGE' => $message,
+				'MESSAGE' => $message->selfForRecipient($i),
 				'ERRORS' => array()
 			);
 			if ($this->_nProtocol === self::PROTOCOL_BINARY) {
@@ -251,7 +251,7 @@ class ApnsPHP_Push extends ApnsPHP_Abstract
 	 *
 	 * @param  $message @type ApnsPHP_Message The message.
 	 * @param  $sReply @type string The reply message.
-	 * @return @type xxx Xxxxx.
+	 * @return bool success of API call
 	 */
 	private function _httpSend(ApnsPHP_Message $message, &$sReply)
 	{


### PR DESCRIPTION
This allows HTTP/2 to work with `$message->addRecipient('endpoint')`