### PR TITLE
Add "getJsonWebToken" to simplify class extension

### DIFF
--- a/ApnsPHP/SharedConfig.php
+++ b/ApnsPHP/SharedConfig.php
@@ -488,14 +488,7 @@ abstract class SharedConfig
 
         if (strpos($this->providerCertFile, '.p8') !== false) {
             $this->logger()->info("Initializing HTTP/2 backend with key.");
-            $key   = new Key\LocalFileReference('file://' . $this->providerCertFile);
-            $token = Configuration::forUnsecuredSigner()->builder()
-                                                        ->issuedBy($this->providerTeamId)
-                                                        ->issuedAt(new DateTimeImmutable())
-                                                        ->withHeader('kid', $this->providerKeyId)
-                                                        ->getToken(new Sha256(), $key);
-
-            $this->providerToken = (string) $token;
+            $this->providerToken = $this->getJsonWebToken();
         }
 
         if (!curl_setopt_array($this->hSocket, $curlOpts)) {
@@ -507,6 +500,19 @@ abstract class SharedConfig
         $this->logger()->info("Initialized HTTP/2 backend.");
 
         return true;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getJsonWebToken()
+    {
+        $key = new Key\LocalFileReference('file://' . $this->providerCertFile);
+        return (string) Configuration::forUnsecuredSigner()->builder()
+            ->issuedBy($this->providerTeamId)
+            ->issuedAt(new DateTimeImmutable())
+            ->withHeader('kid', $this->providerKeyId)
+            ->getToken(new Sha256(), $key);
     }
 
     /**


### PR DESCRIPTION
To make it easier to extend the class and have our own JWT creator (for example to use it with cache)

> For security, APNs requires you to refresh your token regularly. Refresh your token no more than once every 20 minutes and no less than once every 60 minutes. APNs rejects any request whose token contains a timestamp that is more than one hour old. Similarly, APNs reports an error if you recreate your tokens more than once every 20 minutes.
> 
> On your provider server, set up a recurring task to recreate your token with a current timestamp. Encrypt the token again and attach it to subsequent notification requests.

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns#see-also

To go further we should have a `JsonWebTokenProviderInterface` instead of using inheritance