### PR TITLE
Don't log null bytes

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -221,7 +221,7 @@ class Push extends SharedConfig
                         $errorMessage = array(
                             'identifier' => $key,
                             'statusCode' => curl_getinfo($this->hSocket, CURLINFO_HTTP_CODE),
-                            'statusMessage' => $reply
+                            'statusMessage' => str_replace("\0", '', $reply)
                         );
                     }
                 } else {


### PR DESCRIPTION
curl can return some null bytes in some edge cases, this can break the logger

`
\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000@\000\000\000\000@\000\000u\000\000\000\000\000???\000\000\000Unexpected HTTP/1.x request: POST /3/device/...
`