### PR TITLE
Use PROTOCOL_HTTP by default and deprecate PROTOCOL_BINARY

### DIFF
--- a/ApnsPHP/SharedConfig.php
+++ b/ApnsPHP/SharedConfig.php
@@ -129,8 +129,12 @@ abstract class SharedConfig
      * @throws BaseException if the environment is not
      *         sandbox or production or the provider certificate file is not readable.
      */
-    public function __construct($environment, $providerCertificateFile, $protocol = self::PROTOCOL_BINARY)
+    public function __construct($environment, $providerCertificateFile, $protocol = self::PROTOCOL_HTTP)
     {
+        if ($protocol === self::PROTOCOL_BINARY) {
+            @trigger_error('Binary protocol is deprecated and will be removed in the next version', E_USER_DEPRECATED);
+        }
+
         if ($environment != self::ENVIRONMENT_PRODUCTION && $environment != self::ENVIRONMENT_SANDBOX) {
             throw new BaseException(
                 "Invalid environment '{$environment}'"


### PR DESCRIPTION
Because the binary protocol is not supported anymore, I think it would make sense to trigger a deprecation message and use the HTTP as the default one