### PR TITLE
Push: Port PHP8 fix over from ProtonMail

### DIFF
--- a/ApnsPHP/Push.php
+++ b/ApnsPHP/Push.php
@@ -417,6 +417,7 @@ class Push
         if (is_resource($this->hSocket) || is_object($this->hSocket)) {
             $this->logger->info('Disconnected.');
             curl_close($this->hSocket);
+            unset($this->hSocket); // curl_close($handle) has no effect in PHP >= 8.0
             return true;
         }
         return false;


### PR DESCRIPTION
Part of https://github.com/ProtonMail/ApnsPHP/commit/6b4363df7c786534281c4481b4979e9f2148cb56

There's a follow up commit at https://github.com/ProtonMail/ApnsPHP/commit/9a368caafaff4568e542718cb4eaa7b33593b2cb, but I don't think we need that. The `if` statement we have should be sufficient enough