### PR TITLE
General: Relax version requirements in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,16 @@
 	"license": "BSD-3-Clause",
 	"require": {
 		"php": ">=7.4",
-		"psr/log": "^1.1.4",
+		"psr/log": ">=1.1",
 		"lib-openssl": "*",
 		"lcobucci/jwt": "~4.1.5"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~9.0",
-		"lunr/halo": "dev-master"
+		"lunr/halo": "~0.7.0"
+	},
+	"config": {
+		"optimize-autoloader": true
 	},
 	"autoload": {
         "psr-4": {"ApnsPHP\\": "ApnsPHP"}


### PR DESCRIPTION
Stick to released versions of lunr/halo.
Allow using v2 and v3 of psr/log.